### PR TITLE
Rename ModeMQTT.Automatic to .Auto

### DIFF
--- a/hass-actron/Support/ModeMQTT.cs
+++ b/hass-actron/Support/ModeMQTT.cs
@@ -7,7 +7,7 @@ namespace HMX.HASSActron
 {
 	public enum ModeMQTT
 	{
-		Automatic = 0,
+		Auto = 0,
 		Heat = 1,
 		Cool = 2,
 		Fan_Only = 3


### PR DESCRIPTION
Firstly, thank you for this project!

I've set this up over the last couple of evenings and it's roughly worked well.
I have noticed some strange behaviour when setting the AC to "auto" mode. After doing so the state would switch back to "off" despite having turned the unit on. (As an aside, this seems to confuse the HomeKit integration even further, resulting in an inability to turn the unit off via HomeKit)

I did a little investigation and noticed that I was receiving logs in HA:
```
Logger: homeassistant.components.mqtt.climate
Source: components/mqtt/climate.py:472
Integration: MQTT (documentation, issues)

Invalid modes mode: automatic
```

Watching the MQTT topic `actron/aircon/mode` showed that `automatic` was the string used when setting the mode to "auto".

It appears that a mode in an MQTT payload must match one of the modes set in the config, which in turn must be a subset of the [documented modes](https://www.home-assistant.io/integrations/climate.mqtt/):
`[“auto”, “off”, “cool”, “heat”, “dry”, “fan_only”]`

This would indicate that this enumeration should present `.Auto` instead of `.Automatic`

I haven't verified that this fixes my problem as I'm not immediately confident building this; but I can take a stab at that over the coming days if you don't have the bandwidth :)